### PR TITLE
Adding yaml for a simple two-step workflow to clone the repo and then…

### DIFF
--- a/.github/workflows/merge_to_prod.yml
+++ b/.github/workflows/merge_to_prod.yml
@@ -1,0 +1,24 @@
+name: Create a pull request to sync prod with main.
+run-name: Create a pull request to sync prod with main.
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+jobs:
+  make_pr_job:
+    permissions:
+      pull-requests: write
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        run : gh repo clone opensearch-project/foundation-website ./
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create PR
+        run: gh pr create -H main -B prod --title "[prod] Push to production." --body "Autocut PR to merge with prod." -R opensearch-project/foundation-website
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.html_url }}


### PR DESCRIPTION
… create a PR to catch prod up with main.

### Description
Adds a github actions workflow to create a PR when branches are merged with main.

### Issues Resolved
#13 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
